### PR TITLE
updates before editorial resubmission 

### DIFF
--- a/build/pandoc/defaults/common.yaml
+++ b/build/pandoc/defaults/common.yaml
@@ -6,7 +6,7 @@ filters:
 - pandoc-eqnos
 - pandoc-tablenos
 - pandoc-manubot-cite
-- citeproc
+- pandoc-citeproc
 wrap: preserve
 metadata:
   csl: build/assets/style.csl

--- a/content/06.resources.md
+++ b/content/06.resources.md
@@ -1,14 +1,20 @@
 
-### Data and Resource availability
+### Data availability
+
+Due to copyright, we are unable to provide the unprocessed scraped data used in this analysis.
+To ensure reproducability without violating copyright, we provide the word frequencies for each news article, the coreNLP output, all analyzed names with an article identifier, as well as any other associated data used in the analyses such as quotes and citations.
+We provide all of this data on [github](https://github.com/greenelab/nature_news_disparities/tree/main/data).
+We also provide data descriptions in our github README, under the header "Quick data folder overview".
+
+
+### Code availability
 
 This manuscript was written using Manubot [@doi:10.1371/journal.pcbi.1007128] and is available on github: [manuscript repository link](https://github.com/greenelab/nature_news_manuscript). 
 All code and metadata is also available on github, [full analysis repository link](https://github.com/greenelab/nature_news_disparities), under a BSD 3-Clause License.
 The code to generate all main and supplemental figures are available as R markdown documents within our main analysis github, in the following subfolder: [notebooks](https://github.com/greenelab/nature_news_disparities/tree/main/figure_notebooks).
-Due to copyright, we are unable to provide the scraped data used in this analysis.
-However, scraping code is available on our main analysis github, in the following subfolder: [scraper](https://github.com/greenelab/nature_news_disparities/tree/main/nature_news_scraper).
-To ensure reproducability without violating copyright, we provide the word frequencies for each news article and the coreNLP output.
-Furthermore, we provide a docker image that can re-run the analysis pipeline using intermediate, pre-processed data and produce all the main and supplemental figures.
+We provide a docker image that can re-run the analysis pipeline using intermediate, pre-processed data and produce all the main and supplemental figures.
 To re-run the entire pipeline (including scraping), the docker image contains all necessary packages and code. 
+Scraping code is available on our main analysis github, in the following subfolder: [scraper](https://github.com/greenelab/nature_news_disparities/tree/main/nature_news_scraper).
 The shell scripts to re-run the entire analysis are provided in the README file in the github repository.
 
 


### PR DESCRIPTION
Something happened in citeproc, now updated a filter from citeproc to pandoc-citeproc

Also split up Data and Resource Availability into two sections "Data Avail." and "Code Avail"